### PR TITLE
解决SSL: CERTIFICATE_VERIFY_FAILED

### DIFF
--- a/iis_shortname_scan.py
+++ b/iis_shortname_scan.py
@@ -5,6 +5,16 @@
 import sys
 import threading
 import time
+import ssl
+
+try:
+    _create_unverified_https_context = ssl._create_unverified_context
+except AttributeError:
+    # Legacy Python that doesn't verify HTTPS certificates by default
+    pass
+else:
+    # Handle target environment that doesn't support HTTPS verification
+    ssl._create_default_https_context = _create_unverified_https_context
 
 try:
     # python 2.x


### PR DESCRIPTION
在打hackthebox的过程中发现，对https 网站的自有证书会出错。所以增加了相关处理。